### PR TITLE
Use meme generator if saved message is an URL

### DIFF
--- a/cogs/msg.py
+++ b/cogs/msg.py
@@ -1,7 +1,6 @@
 import re
 from urllib.parse import urlparse, quote
 from discord.ext import commands
-from discord.utils import escape_mentions
 
 import basedbot
 
@@ -134,11 +133,11 @@ class MessageStore(commands.Cog):
             await ctx.send("Shorthand text must be a valid URL to enable meme generation.")
             return
 
-        safe_caption = escape_mentions(caption)
-        safe_caption = _memegen_escape_text(safe_caption)
+        safe_caption = _memegen_escape_text(caption)
         safe_caption = quote(safe_caption, safe='')
+        quoted_url = quote(shorthand_url, safe='')
 
-        text = f"https://api.memegen.link/images/custom/_/{safe_caption}.gif?background={shorthand_url}"
+        text = f"https://api.memegen.link/images/custom/_/{safe_caption}.gif?background={quoted_url}"
 
         await ctx.send(text)
 

--- a/cogs/msg.py
+++ b/cogs/msg.py
@@ -1,9 +1,40 @@
 import re
 from urllib.parse import urlparse, quote
-
 from discord.ext import commands
+from discord.utils import escape_mentions
 
 import basedbot
+
+
+def _is_url(text):
+    try:
+        result = urlparse(text)
+        return all([result.scheme, result.netloc, result.path])
+    except:
+        return False
+
+def _memegen_escape_text(text):
+    # according to https://memegen.link/#special-characters
+    escapes = [
+        ("_", "__"),
+        ("-", "--"),
+        (" ", "_"),
+        ("\n", "~n"),
+        ("?", "~q"),
+        ("&", "~a"),
+        ("%", "~p"),
+        ("#", "~h"),
+        ("/", "~s"),
+        ("\\", "~b"),
+        ("<", "~l"),
+        (">", "~g"),
+        ("\"", "''"),
+    ]
+
+    for char, escape in escapes:
+        text = text.replace(char, escape)
+
+    return text
 
 
 class MessageStore(commands.Cog):
@@ -39,12 +70,74 @@ class MessageStore(commands.Cog):
         content = await commands.clean_content().convert(ctx, content)
 
         with self.bot.db.get(ctx.guild.id) as db:
-            if len(db.execute("SELECT name, content FROM msg WHERE name = ?", (name.lower(),)).fetchall()) > 0:
-                db.execute("UPDATE msg SET content = ? WHERE name = ?", (content, name.lower()))
+            current_msg = db.execute(
+                "SELECT name, content, allow_memegen FROM msg WHERE name = ?", (name.lower(),)).fetchall()
+            if len(current_msg) > 0:
+                # only allow memegen if the current message is still an URL
+                keep_memegen = current_msg[0][2] and _is_url(content)
+                db.execute("UPDATE msg SET content = ?, allow_memegen = ? WHERE name = ?", (content, keep_memegen, name.lower()))
             else:
                 db.execute("INSERT INTO msg (name, content) VALUES (?, ?)", (name.lower(), content))
 
         await ctx.message.add_reaction('\U00002705')
+
+    @msg.command()
+    @basedbot.has_permissions("msg.set")
+    async def memegen(self, ctx, action, shorthand):
+        """Enable or disable meme generation for a shorthand"""
+
+        if action not in ("enable", "disable"):
+            await ctx.send("Invalid action. Valid actions are `enable` and `disable`")
+            return
+
+        with self.bot.db.get(ctx.guild.id) as db:
+            result = db.execute("SELECT name, content FROM msg WHERE name = ? OR name = ?",
+                                (shorthand.lower(), "-" + shorthand.lower())).fetchall()
+
+        if len(result) <= 0:
+            await ctx.send("Shorthand not found.")
+            return
+
+        shorthand_text = result[0][1]
+        if not _is_url(shorthand_text):
+            await ctx.send("Shorthand text must be a valid URL to enable meme generation.")
+            return
+
+        with self.bot.db.get(ctx.guild.id) as db:
+            result = db.execute("UPDATE msg SET allow_memegen = ? WHERE name = ? OR name = ?", (
+                action == "enable", shorthand.lower(), "-" + shorthand.lower()))
+
+        await ctx.message.add_reaction('\U00002705')
+
+    @msg.command()
+    @basedbot.has_permissions("msg.caption")
+    async def caption(self, ctx, shorthand, *, caption: commands.clean_content(fix_channel_mentions=True, use_nicknames=True)):
+        """Caption a meme"""
+
+        with self.bot.db.get(ctx.guild.id) as db:
+            result = db.execute("SELECT name, content, allow_memegen FROM msg WHERE name = ? OR name = ?",
+                                (shorthand.lower(), "-" + shorthand.lower())).fetchall()
+
+        if len(result) <= 0:
+            await ctx.send("Shorthand not found.")
+            return
+
+        if not result[0][2]:
+            await ctx.send("Meme generation has not been enabled for this shorthand.")
+            return
+
+        shorthand_url = result[0][1]
+        if not _is_url(shorthand_url):
+            await ctx.send("Shorthand text must be a valid URL to enable meme generation.")
+            return
+
+        safe_caption = escape_mentions(caption)
+        safe_caption = _memegen_escape_text(safe_caption)
+        safe_caption = quote(safe_caption, safe='')
+
+        text = f"https://api.memegen.link/images/custom/_/{safe_caption}.gif?background={shorthand_url}"
+
+        await ctx.send(text)
 
     @msg.command()
     @basedbot.has_permissions("msg.delete")
@@ -76,29 +169,16 @@ class MessageStore(commands.Cog):
         if len(result) == 0:
             return
 
-        text = result[0][1]
-
-        def isUrl(url):
-            try:
-                result = urlparse(url)
-                return all([result.scheme, result.netloc])
-            except:
-                return False
-
-        rest = message.clean_content[search.end():].strip()
-        if isUrl(text) and len(rest) > 0:
-            rest = re.sub(r'\s+', '_', rest)
-            rest = quote(rest, safe='/')
-            text = f"https://api.memegen.link/images/custom/_/{rest}.gif?background={text}"
-
-        await message.channel.send(text)
-
+        await message.channel.send(result[0][1])
 
 def setup(bot):
     # pylint: disable=missing-function-docstring
     bot.perm.register('msg.list',
                       base=True,
                       pretty_name="List shorthands (msg)")
+    bot.perm.register('msg.caption',
+                      base=True,
+                      pretty_name="Caption images (msg)")
     bot.perm.register('msg.set',
                       base="administrator",
                       pretty_name="Create/Update shorthands (msg)")

--- a/cogs/msg.py
+++ b/cogs/msg.py
@@ -10,7 +10,7 @@ def _is_url(text):
     try:
         result = urlparse(text)
         return all([result.scheme, result.netloc, result.path])
-    except:
+    except ValueError:
         return False
 
 def _memegen_escape_text(text):
@@ -75,7 +75,8 @@ class MessageStore(commands.Cog):
             if len(current_msg) > 0:
                 # only allow memegen if the current message is still an URL
                 keep_memegen = current_msg[0][2] and _is_url(content)
-                db.execute("UPDATE msg SET content = ?, allow_memegen = ? WHERE name = ?", (content, keep_memegen, name.lower()))
+                db.execute("UPDATE msg SET content = ?, allow_memegen = ? WHERE name = ?",
+                           (content, keep_memegen, name.lower()))
             else:
                 db.execute("INSERT INTO msg (name, content) VALUES (?, ?)", (name.lower(), content))
 
@@ -100,7 +101,7 @@ class MessageStore(commands.Cog):
 
         shorthand_text = result[0][1]
         if not _is_url(shorthand_text):
-            await ctx.send("Shorthand text must be a valid URL to enable meme generation.")
+            await ctx.send("Shorthand text must be a valid URL to manage meme generation.")
             return
 
         with self.bot.db.get(ctx.guild.id) as db:
@@ -111,7 +112,9 @@ class MessageStore(commands.Cog):
 
     @msg.command()
     @basedbot.has_permissions("msg.caption")
-    async def caption(self, ctx, shorthand, *, caption: commands.clean_content(fix_channel_mentions=True, use_nicknames=True)):
+    async def caption(self, ctx, shorthand, *, caption: commands.clean_content(
+        fix_channel_mentions=True, use_nicknames=True
+    )):
         """Caption a meme"""
 
         with self.bot.db.get(ctx.guild.id) as db:

--- a/cogs/msg.py
+++ b/cogs/msg.py
@@ -1,4 +1,6 @@
 import re
+from urllib.parse import urlparse, quote
+
 from discord.ext import commands
 
 import basedbot
@@ -74,7 +76,22 @@ class MessageStore(commands.Cog):
         if len(result) == 0:
             return
 
-        await message.channel.send(result[0][1])
+        text = result[0][1]
+
+        def isUrl(url):
+            try:
+                result = urlparse(url)
+                return all([result.scheme, result.netloc])
+            except:
+                return False
+
+        rest = message.clean_content[search.end():].strip()
+        if isUrl(text) and len(rest) > 0:
+            rest = re.sub(r'\s+', '_', rest)
+            rest = quote(rest, safe='/')
+            text = f"https://api.memegen.link/images/custom/_/{rest}.gif?background={text}"
+
+        await message.channel.send(text)
 
 
 def setup(bot):

--- a/sql/guild/msg_2.sql
+++ b/sql/guild/msg_2.sql
@@ -1,0 +1,3 @@
+ALTER TABLE msg ADD allow_memegen BOOLEAN NOT NULL DEFAULT FALSE;
+
+PRAGMA user_version = 2;


### PR DESCRIPTION
See suggestion 405 on the TUM CS Discord server.

This allows users to caption memes right from the bot commands, e.g. the following will work:

```
$1984 Stop spamming
```

will send the following link (if the message `1984` is set to `https://media.tenor.com/qmSIzc-H7vIAAAAC/1984.gif`):

```
https://api.memegen.link/images/custom/_/Stop_spamming.gif?background=https://media.tenor.com/qmSIzc-H7vIAAAAC/1984.gif
```

Discord will of course embed that link correctly.

I tested this on a test server and it mostly works except for this known problem:
* `/` is not escaped correctly, but it appears that the used API does not accept it correctly even when escaped correctly (even when setting `safe=''` in `quote`)