### PR TITLE
Directly send Memegen images instead of a link

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 discord.py>=2.1.0,<3.0.0
+aiohttp==3.8.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 discord.py>=2.1.0,<3.0.0
-aiohttp==3.8.3
+aiohttp>=3.8,<4.0


### PR DESCRIPTION
This prevents the typical "Embed fail" where the bot sends a link, but the API does not respond fast enough for Discord to embed the file:
![image](https://user-images.githubusercontent.com/32465636/228343872-b12e1495-1066-4802-abeb-ccbaed42d5fb.png)

It just downloads the file to the bots' memory and then sends it to Discord instead of only sending the link. I restricted the size to 32MB to prevent infinite memory usage.

Another thing is that the bot sends typing while the download and upload happen, which is quite nice.

I tested this both locally and via Docker.